### PR TITLE
Gaps and recovery

### DIFF
--- a/App.config
+++ b/App.config
@@ -21,6 +21,10 @@
 	<add key="PositionXOffset" value="0x24C"/>
 	<add key="PositionYOffset" value="0x250"/>
 	<add key="PositionOffset" value="0x2AD0C"/>
+	<add key="HitstopOffset" value="0x1AC"/>
+	<add key="Flags0x4d3cOffset" value="0x4D3C"/>
+	<add key="Flags0x4d48Offset" value="0x4D48"/>
+	<add key="ForceDisableFlagsOffset" value="0x24E3C"/>
 		
 	<add key="FrameCountOffset" value="0x193C7A4" />
 

--- a/Labtool.cs
+++ b/Labtool.cs
@@ -63,7 +63,7 @@ class Labtool
 			{
 				if (g.idleCount <= 30)
 				{
-					g.rememberGap = g.idleCount;
+					g.rememberGap = g.idleCount + 1;
 					g.updateGap = true;
 					g.idleCount = 0;
 				}

--- a/Labtool.cs
+++ b/Labtool.cs
@@ -100,6 +100,14 @@ class Labtool
 		_player2._isHit = MemoryAccessor.ReadInfoInt(ref _player2, MemoryAccessor._HitstunOffset) != 0;
 		_player1._currentAnim = MemoryAccessor.ReadAnimationString(ref _player1);
 		_player2._currentAnim = MemoryAccessor.ReadAnimationString(ref _player2);
+		_player1._hitstop = MemoryAccessor.ReadHitstop(ref _player1);
+		_player2._hitstop = MemoryAccessor.ReadHitstop(ref _player2);
+		_player1._flags0x4d3c = MemoryAccessor.ReadFlags0x4d3c(ref _player1);
+		_player2._flags0x4d3c = MemoryAccessor.ReadFlags0x4d3c(ref _player2);
+		_player1._flags0x4d48 = MemoryAccessor.ReadFlags0x4d48(ref _player1);
+		_player2._flags0x4d48 = MemoryAccessor.ReadFlags0x4d48(ref _player2);
+		_player1._forceDisableFlags = MemoryAccessor.ReadForceDisableFlags(ref _player1);
+		_player2._forceDisableFlags = MemoryAccessor.ReadForceDisableFlags(ref _player2);
 
 		frameAdvantage(f, ref _player1, ref _player2);
 		gap(g1, ref _player2);

--- a/MemoryAccessor.cs
+++ b/MemoryAccessor.cs
@@ -26,6 +26,10 @@ class MemoryAccessor
 
 	public static readonly int _BlockstunOffset = Convert.ToInt32(ConfigurationManager.AppSettings.Get("BlockstunOffset"), 16);
 	public static readonly int _HitstunOffset = Convert.ToInt32(ConfigurationManager.AppSettings.Get("HitstunOffset"), 16);
+	public static readonly int _HitstopOffset = Convert.ToInt32(ConfigurationManager.AppSettings.Get("HitstopOffset"), 16);
+	public static readonly int _Flags0x4d3cOffset = Convert.ToInt32(ConfigurationManager.AppSettings.Get("Flags0x4d3cOffset"), 16);
+	public static readonly int _Flags0x4d48Offset = Convert.ToInt32(ConfigurationManager.AppSettings.Get("Flags0x4d48Offset"), 16);
+	public static readonly int _ForceDisableFlagsOffset = Convert.ToInt32(ConfigurationManager.AppSettings.Get("ForceDisableFlagsOffset"), 16);
 	#endregion
 
 
@@ -133,6 +137,26 @@ class MemoryAccessor
 			Dispose();
 			return 0;
 		}
+	}
+
+	public static int ReadHitstop(ref Player player)
+	{
+		return ReadInfoInt(ref player, _HitstopOffset);
+	}
+
+	public static int ReadFlags0x4d3c(ref Player player)
+	{
+		return ReadInfoInt(ref player, _Flags0x4d3cOffset);
+	}
+
+	public static int ReadFlags0x4d48(ref Player player)
+	{
+		return ReadInfoInt(ref player, _Flags0x4d48Offset);
+	}
+
+	public static int ReadForceDisableFlags(ref Player player)
+	{
+		return ReadInfoInt(ref player, _ForceDisableFlagsOffset);
 	}
 
 	public static void Dispose()

--- a/README.md
+++ b/README.md
@@ -23,6 +23,5 @@ External tool adding more features to the training mode of Guilty Gear Xrd Rev2.
 - Crashes when changing characters, hence the recommendation.
 - If you have the wrong characters displayed, you may want to hit left then right on the training menu's selected characters so that Labtool updates.
 - Playing as P2 swaps some info on the display.
-- Attacks such as blitz or Ramlethal 5PPP have a part of their recovery animation which is cancellable but has no (found) indication of being so. To display the proper frame advantage from those attacks, cancel the recovery with walk.
 
 The project migrated from .NET Core to .NET Framework for compatibility purposes. 


### PR DESCRIPTION
This pull requests makes the following changes:

1) Display gaps +1 from what the program currently does. For example, right now, Ky 5K 5H blockstring would be displayed with a 0F gap, but it's actually a 1F gap, and so on. Lots of people are confused by the current display of gaps 1 less from what it actually is.

2) Recognize recovery of moves like Ramlethal 5PPP, 5D6 (on hit), 5D8 (on hit), Blitz Shield (reject) and so on. Including the following moves:

    - Chipp wall cling: idle or moving up/down - considered "idle";
    - Faust pogo stance - considered "idle" when not doing a pogo move;
    - Axl Haitaka stance - considered "idle" when not doing a stance move;
    - Elphelt sniper rifle - considered "idle" as soon as able to fire the rifle (first possible uncharged shot);
    - Leo backturn stance - considered "idle";
    - Jam parry - considered "**not** idle" (the tool already recognized it as not idle before this fix, it's just listed here because it's an exception from the general rule used by the new logic);
    - Answer scroll cling - considered "idle" when not doing a move, except sc.D. Scroll D can be canceled into any scroll move at any time on block, hit or whiff.